### PR TITLE
Improve debug description of Accidental and Tone

### DIFF
--- a/MusicNotationKit/MusicNotationKit.xcodeproj/project.pbxproj
+++ b/MusicNotationKit/MusicNotationKit.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		27AA71151C9140C400E2BF22 /* RepeatedMeasure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AA71141C9140C400E2BF22 /* RepeatedMeasure.swift */; };
 		27AA71171C9146FD00E2BF22 /* MeasureRepeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AA71161C9146FD00E2BF22 /* MeasureRepeatTests.swift */; };
 		27B670511B9ACDCE00347C4C /* StaffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B670501B9ACDCE00347C4C /* StaffTests.swift */; };
+		E98D30AE1D4BFB7100C6DF5E /* ToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98D30AD1D4BFB7100C6DF5E /* ToneTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 		27AA71141C9140C400E2BF22 /* RepeatedMeasure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedMeasure.swift; sourceTree = "<group>"; };
 		27AA71161C9146FD00E2BF22 /* MeasureRepeatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureRepeatTests.swift; sourceTree = "<group>"; };
 		27B670501B9ACDCE00347C4C /* StaffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaffTests.swift; sourceTree = "<group>"; };
+		E98D30AD1D4BFB7100C6DF5E /* ToneTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +151,7 @@
 				275A58D11B54BD8B0023D5EF /* MeasureTests.swift */,
 				27B670501B9ACDCE00347C4C /* StaffTests.swift */,
 				27AA71161C9146FD00E2BF22 /* MeasureRepeatTests.swift */,
+				E98D30AD1D4BFB7100C6DF5E /* ToneTests.swift */,
 			);
 			path = MusicNotationKitTests;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 				275A58D21B54BD8B0023D5EF /* MeasureTests.swift in Sources */,
 				27AA71171C9146FD00E2BF22 /* MeasureRepeatTests.swift in Sources */,
 				27B670511B9ACDCE00347C4C /* StaffTests.swift in Sources */,
+				E98D30AE1D4BFB7100C6DF5E /* ToneTests.swift in Sources */,
 				27A0AA4A1B524B6400635541 /* TestHelpers.swift in Sources */,
 				270CC5311B2C06A200CA1A56 /* MusicNotationKitTests.swift in Sources */,
 				270F46B11B353DF400FDF4FF /* TupletTests.swift in Sources */,

--- a/MusicNotationKit/MusicNotationKit/Tone.swift
+++ b/MusicNotationKit/MusicNotationKit/Tone.swift
@@ -27,7 +27,7 @@ extension Tone: CustomDebugStringConvertible {
 		} else {
 			accidentalString = ""
 		}
-		return "\(noteLetter)\(octave.rawValue)\(accidentalString)"
+		return "\(noteLetter)\(accidentalString)\(octave.rawValue)"
 	}
 }
 

--- a/MusicNotationKit/MusicNotationKit/Types.swift
+++ b/MusicNotationKit/MusicNotationKit/Types.swift
@@ -60,11 +60,11 @@ public enum Accidental {
 extension Accidental: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
-        case .sharp: return "#"
-        case .doubleSharp: return "##"
-        case .flat: return "b"
-        case .doubleFlat: return "bb"
-        case .natural: return "n"
+        case .sharp: return "♯"
+        case .doubleSharp: return "𝄪"
+        case .flat: return "♭"
+        case .doubleFlat: return "𝄫"
+        case .natural: return "♮"
         }
     }
 }

--- a/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
@@ -1,0 +1,57 @@
+//
+//  ToneTests.swift
+//  MusicNotationKit
+//
+//  Created by Rob Hudson on 7/29/16.
+//  Copyright © 2016 Kyle Sherman. All rights reserved.
+//
+
+import XCTest
+import MusicNotationKit
+
+class ToneTests: XCTestCase {
+
+    func testTone1() {
+        let tone = Tone(accidental: nil, noteLetter: .c, octave: .octave3)
+        XCTAssertTrue(tone.debugDescription == "c3")
+    }
+    
+    func testTone2() {
+        let tone = Tone(accidental: .sharp, noteLetter: .g, octave: .octave6)
+        XCTAssertTrue(tone.debugDescription == "g♯6")
+    }
+
+    func testTone3() {
+        let tone = Tone(accidental: .flat, noteLetter: .e, octave: .octave2)
+        XCTAssertTrue(tone.debugDescription == "e♭2")
+    }
+    
+    func testTone4() {
+        let tone = Tone(accidental: .natural, noteLetter: .a, octave: .octave4)
+        XCTAssertTrue(tone.debugDescription == "a♮4")
+    }
+    
+    func testTone5() {
+        let tone = Tone(accidental: .doubleSharp, noteLetter: .b, octave: .octave5)
+        XCTAssertTrue(tone.debugDescription == "b𝄪5")
+    }
+    
+    func testTone6() {
+        let tone = Tone(accidental: .doubleFlat, noteLetter: .f, octave: .octave7)
+        XCTAssertTrue(tone.debugDescription == "f𝄫7")
+    }
+    
+    func testEqual() {
+        let tone1 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        
+        XCTAssertEqual(tone1, tone2)
+    }
+    
+    func testNotEqual() {
+        let tone1 = Tone(accidental: .flat, noteLetter: .b, octave: .octave5)
+        let tone2 = Tone(accidental: .flat, noteLetter: .b, octave: .octave4)
+        
+        XCTAssertNotEqual(tone1, tone2)
+    }
+}


### PR DESCRIPTION
Use unicode sharp, flat, and natural symbols, and update Tone to place accidental next to note letter.