### PR TITLE
Fix Issue: Staff.insertMeasure uses wrong index for insert

### DIFF
--- a/MusicNotationKit/MusicNotationKit/Staff.swift
+++ b/MusicNotationKit/MusicNotationKit/Staff.swift
@@ -64,11 +64,11 @@ public struct Staff {
         let notesHolderIndex = try notesHolderIndexFromMeasureIndex(index)
         // Not a repeat, just insert
         if notesHolderIndex.repeatMeasureIndex == nil {
-            notesHolders.insert(measure, at: index)
+            notesHolders.insert(measure, at: notesHolderIndex.notesHolderIndex)
             measureCount += measure.measureCount
         } else {
             if beforeRepeat && notesHolderIndex.repeatMeasureIndex == 0 {
-                notesHolders.insert(measure, at: index)
+                notesHolders.insert(measure, at: notesHolderIndex.notesHolderIndex)
                 measureCount += measure.measureCount
                 return
             }

--- a/MusicNotationKit/MusicNotationKitTests/StaffTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/StaffTests.swift
@@ -125,6 +125,23 @@ class StaffTests: XCTestCase {
         }
     }
 
+	func testInsertMeasureNoRepeatAtEnd() {
+		let measure = Measure(
+			timeSignature: TimeSignature(topNumber: 4, bottomNumber: 4, tempo: 120),
+			key: Key(noteLetter: .c))
+		do {
+			try staff.insertMeasure(measure, at: 14)
+			let addedMeasure = try staff.measure(at: 14)
+			let beforeMeasure = try staff.measure(at: 13)
+			let afterMeasure = try staff.measure(at: 15)
+			XCTAssertEqual(Measure(addedMeasure), measure)
+			XCTAssertEqual(Measure(beforeMeasure), measure6)
+			XCTAssertEqual(Measure(afterMeasure), measure3)
+		} catch {
+			XCTFail(String(describing: error))
+		}
+	}
+	
     func testInsertMeasureInRepeat() {
         let measure = Measure(
             timeSignature: TimeSignature(topNumber: 4, bottomNumber: 4, tempo: 120),


### PR DESCRIPTION
This solves issue #41.

Added test case that exposes the issue.