### PR TITLE
Implemented helper method for equivalence of note durations

### DIFF
--- a/MusicNotationKit/MusicNotationKit/NoteDuration.swift
+++ b/MusicNotationKit/MusicNotationKit/NoteDuration.swift
@@ -82,6 +82,48 @@ public struct NoteDuration {
     public static let sixtyFourth = NoteDuration(value: .sixtyFourth)
     public static let oneTwentyEighth = NoteDuration(value: .oneTwentyEighth)
     public static let twoFiftySixth = NoteDuration(value: .twoFiftySixth)
+
+    public static func number(of noteDuration: NoteDuration, equalTo baseNoteDuration: NoteDuration) -> Double {
+        let mathValues: [NoteDuration.Value: Int] = [
+            .long: 2048,
+            .large: 1024,
+            .doubleWhole: 512,
+            .whole: 256,
+            .half: 128,
+            .quarter: 64,
+            .eighth: 32,
+            .sixteenth: 16,
+            .thirtySecond: 8,
+            .sixtyFourth: 4,
+            .oneTwentyEighth: 2,
+            .twoFiftySixth: 1
+        ]
+
+        func mathValue(for duration: NoteDuration) -> Int {
+            var mathValue = mathValues[duration.value] ?? 0
+            var dotValue = mathValue / 2
+            for _ in 0..<duration.dotCount {
+                mathValue += dotValue
+                dotValue = dotValue / 2
+            }
+            return mathValue
+        }
+
+        let baseMathValue = mathValue(for: baseNoteDuration)
+        let equalityMathValue = mathValue(for: noteDuration)
+
+        let fullNotes = Double(baseMathValue / equalityMathValue)
+        if fullNotes >= 1 {
+            let decimalValue = Double(baseMathValue % equalityMathValue) / Double(baseMathValue)
+            return fullNotes + decimalValue
+        } else {
+            return Double(baseMathValue) / Double(equalityMathValue)
+        }
+    }
+
+    public func equal(to noteDuration: NoteDuration) -> Double {
+        return NoteDuration.number(of: noteDuration, equalTo: self)
+    }
 }
 
 extension NoteDuration: Hashable {

--- a/MusicNotationKit/MusicNotationKitTests/NoteDurationTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/NoteDurationTests.swift
@@ -86,6 +86,65 @@ class NoteDurationTests: XCTestCase {
         }
     }
 
+    // MARK: - equal(to:)
+    // MARK: Successes
+
+    func testEqualToForSameDuration() {
+        let noteDuration = NoteDuration.eighth
+        XCTAssertEqual(noteDuration.equal(to: NoteDuration.eighth), 1)
+    }
+
+    func testEqualToForSameDurationSingleDot() {
+        do {
+            let noteDuration = try NoteDuration(value: .quarter, dotCount: 1)
+            XCTAssertEqual(noteDuration.equal(to: try NoteDuration(value: .quarter, dotCount: 1)), 1)
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
+    func testEqualToForSameDurationMultipleDot() {
+        do {
+            let noteDuration = try NoteDuration(value: .quarter, dotCount: 3)
+            XCTAssertEqual(noteDuration.equal(to: try NoteDuration(value: .quarter, dotCount: 3)), 1)
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
+    func testEqualToForSmallerDuration() {
+        let noteDuration = NoteDuration.sixteenth
+        XCTAssertEqual(noteDuration.equal(to: NoteDuration.sixtyFourth), 4)
+    }
+
+    func testEqualToForLargerDuration() {
+        let noteDuration = NoteDuration.quarter
+        XCTAssertEqual(noteDuration.equal(to: NoteDuration.whole), 0.25)
+    }
+
+    func testEqualToForSmallerDurationSingleDotFromNoDot() {
+        let noteDuration = NoteDuration.quarter
+        XCTAssertEqual(noteDuration.equal(to: try NoteDuration(value: .eighth, dotCount: 1)), 1.25)
+    }
+
+    func testEqualToForSmallerDurationSingleDotFromSingleDot() {
+        do {
+            let noteDuration = try NoteDuration(value: .quarter, dotCount: 1)
+            XCTAssertEqual(noteDuration.equal(to: try NoteDuration(value: .sixteenth, dotCount: 1)), 4)
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
+    func testEqualToForSmallerDurationDoubleDotFromDoubleDot() {
+        do {
+            let noteDuration = try NoteDuration(value: .quarter, dotCount: 2)
+            XCTAssertEqual(noteDuration.equal(to: try NoteDuration(value: .thirtySecond, dotCount: 2)), 8)
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
     // MARK: - debugDescription
 
     func testDebugDescriptionNoDot() {


### PR DESCRIPTION
This will be used in #33 for validating a `Tuplet` during initialization.