### PR TITLE
Add Enharmonic protocol and comparison for Tone

### DIFF
--- a/MusicNotationKit/MusicNotationKit.xcodeproj/project.pbxproj
+++ b/MusicNotationKit/MusicNotationKit.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E92BD6031D4FD0A500061BCD /* Interval.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92BD6021D4FD0A500061BCD /* Interval.swift */; };
 		E92BD6051D4FD0FF00061BCD /* IntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92BD6041D4FD0FF00061BCD /* IntervalTests.swift */; };
 		E98D30AE1D4BFB7100C6DF5E /* ToneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98D30AD1D4BFB7100C6DF5E /* ToneTests.swift */; };
+		E9D762E11D8C4ECC0005AAB6 /* Enharmonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D762E01D8C4ECC0005AAB6 /* Enharmonic.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		E92BD6021D4FD0A500061BCD /* Interval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interval.swift; sourceTree = "<group>"; };
 		E92BD6041D4FD0FF00061BCD /* IntervalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntervalTests.swift; sourceTree = "<group>"; };
 		E98D30AD1D4BFB7100C6DF5E /* ToneTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneTests.swift; sourceTree = "<group>"; };
+		E9D762E01D8C4ECC0005AAB6 /* Enharmonic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enharmonic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 				27AA71121C8D1BD900E2BF22 /* ImmutableMeasure.swift */,
 				27AA71141C9140C400E2BF22 /* RepeatedMeasure.swift */,
 				27AFEB561D6984CB0064ED27 /* NoteDuration.swift */,
+				E9D762E01D8C4ECC0005AAB6 /* Enharmonic.swift */,
 				270CC5211B2C06A200CA1A56 /* Supporting Files */,
 			);
 			path = MusicNotationKit;
@@ -298,6 +301,7 @@
 				E92BD6031D4FD0A500061BCD /* Interval.swift in Sources */,
 				270F46A31B2FE4D900FDF4FF /* NoteHolder.swift in Sources */,
 				27AFEB571D6984CB0064ED27 /* NoteDuration.swift in Sources */,
+				E9D762E11D8C4ECC0005AAB6 /* Enharmonic.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MusicNotationKit/MusicNotationKit/Enharmonic.swift
+++ b/MusicNotationKit/MusicNotationKit/Enharmonic.swift
@@ -1,0 +1,13 @@
+//
+//  Enharmonic.swift
+//  MusicNotationKit
+//
+//  Created by Rob Hudson on 9/16/16.
+//  Copyright © 2016 Kyle Sherman. All rights reserved.
+//
+
+import Foundation
+
+public protocol Enharmonic: Equatable {
+    func isEnharmonic(with other: Self) -> Bool
+}

--- a/MusicNotationKit/MusicNotationKit/Tone.swift
+++ b/MusicNotationKit/MusicNotationKit/Tone.swift
@@ -42,3 +42,40 @@ extension Tone: Equatable {
         }
     }
 }
+
+extension Tone {
+    public var midiNoteNumber: Int {
+        var result = (octave.rawValue + 1) * 12
+        
+        switch noteLetter {
+        case .c: break
+        case .d: result += 2
+        case .e: result += 4
+        case .f: result += 5
+        case .g: result += 7
+        case .a: result += 9
+        case .b: result += 11
+        }
+        
+        switch accidental {
+        case .flat?:
+            result -= 1
+        case .sharp?:
+            result += 1
+        case .doubleFlat?:
+            result -= 2
+        case .doubleSharp?:
+            result += 2
+        default:
+            break
+        }
+        
+        return result
+    }
+}
+
+extension Tone: Enharmonic {
+    public func isEnharmonic(with other: Tone) -> Bool {
+        return self.midiNoteNumber == other.midiNoteNumber
+    }
+}

--- a/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
@@ -42,6 +42,15 @@ class ToneTests: XCTestCase {
     }
     
     // MARK: - ==
+    // MARK: Failures
+    
+    func testNotEqual() {
+        let tone1 = Tone(accidental: .flat, noteLetter: .b, octave: .octave5)
+        let tone2 = Tone(accidental: .flat, noteLetter: .b, octave: .octave4)
+        
+        XCTAssertNotEqual(tone1, tone2)
+    }
+
     // MARK: Successes
     
     func testEqual() {
@@ -51,16 +60,7 @@ class ToneTests: XCTestCase {
         XCTAssertEqual(tone1, tone2)
     }
     
-    // MARK: Failures
-    
-    func testNotEqual() {
-        let tone1 = Tone(accidental: .flat, noteLetter: .b, octave: .octave5)
-        let tone2 = Tone(accidental: .flat, noteLetter: .b, octave: .octave4)
-        
-        XCTAssertNotEqual(tone1, tone2)
-    }
-    
-    // MARK: - Midi numbers
+    // MARK: - MIDI numbers
     // MARK: Successes
     
     func testRidiculouslyLowNote() {
@@ -87,7 +87,33 @@ class ToneTests: XCTestCase {
         XCTAssertEqual(tone.midiNoteNumber, 107)
     }
     
-    // MARK: - Enharmonic
+    // MARK: - isEnharmonic(with:)
+    // MARK: Failures
+    
+    func testDifferentAccidentals() {
+        let tone1 = Tone(accidental: .flat, noteLetter: .d, octave: .octave1)
+        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testSamePitchDifferentOctaves() {
+        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave5)
+        let tone2 = Tone(accidental: .natural, noteLetter: .e, octave: .octave6)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testEnharmonicPitchDifferentOctaves() {
+        let tone1 = Tone(accidental: .doubleSharp, noteLetter: .f, octave: .octave2)
+        let tone2 = Tone(accidental: .natural, noteLetter: .g, octave: .octave5)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
+    }
+
     // MARK: Successes
     
     func testSameToneIsEnharmonic() {
@@ -132,21 +158,4 @@ class ToneTests: XCTestCase {
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))
     }
     
-    // MARK: Failures
-    
-    func testDifferentAccidentals() {
-        let tone1 = Tone(accidental: .flat, noteLetter: .d, octave: .octave1)
-        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
-        
-        XCTAssertNotEqual(tone1, tone2)
-        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
-    }
-    
-    func testDifferentOctaves() {
-        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave5)
-        let tone2 = Tone(accidental: .natural, noteLetter: .e, octave: .octave6)
-        
-        XCTAssertNotEqual(tone1, tone2)
-        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
-    }
 }

--- a/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
@@ -41,6 +41,9 @@ class ToneTests: XCTestCase {
         XCTAssertTrue(tone.debugDescription == "f𝄫7")
     }
     
+    // MARK: - ==
+    // MARK: Successes
+    
     func testEqual() {
         let tone1 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
         let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
@@ -48,10 +51,102 @@ class ToneTests: XCTestCase {
         XCTAssertEqual(tone1, tone2)
     }
     
+    // MARK: Failures
+    
     func testNotEqual() {
         let tone1 = Tone(accidental: .flat, noteLetter: .b, octave: .octave5)
         let tone2 = Tone(accidental: .flat, noteLetter: .b, octave: .octave4)
         
         XCTAssertNotEqual(tone1, tone2)
+    }
+    
+    // MARK: - Midi numbers
+    // MARK: Successes
+    
+    func testRidiculouslyLowNote() {
+        let tone = Tone(accidental: .natural, noteLetter: .c, octave: .octaveNegative1)
+        
+        XCTAssertEqual(tone.midiNoteNumber, 0)
+    }
+    
+    func testLowNote() {
+        let tone = Tone(accidental: .sharp, noteLetter: .f, octave: .octave1)
+        
+        XCTAssertEqual(tone.midiNoteNumber, 30)
+    }
+    
+    func testMidRangeNote() {
+        let tone = Tone(accidental: nil, noteLetter: .d, octave: .octave4)
+        
+        XCTAssertEqual(tone.midiNoteNumber, 62)
+    }
+    
+    func testHighNote() {
+        let tone = Tone(accidental: .flat, noteLetter: .c, octave: .octave8)
+        
+        XCTAssertEqual(tone.midiNoteNumber, 107)
+    }
+    
+    // MARK: - Enharmonic
+    // MARK: Successes
+    
+    func testSameToneIsEnharmonic() {
+        let tone1 = Tone(accidental: .natural, noteLetter: .g, octave: .octave6)
+        let tone2 = Tone(accidental: .natural, noteLetter: .g, octave: .octave6)
+        
+        XCTAssertEqual(tone1, tone2)
+        XCTAssertTrue(tone1.isEnharmonic(with: tone2))
+        // Transitive property
+        XCTAssertTrue(tone2.isEnharmonic(with: tone1))
+    }
+    
+    func testEnharmonicNotEquatable() {
+        let tone1 = Tone(accidental: .flat, noteLetter: .a, octave: .octave3)
+        let tone2 = Tone(accidental: .sharp, noteLetter: .g, octave: .octave3)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertTrue(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testNaturalAndFlat() {
+        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave4)
+        let tone2 = Tone(accidental: .flat, noteLetter: .f, octave: .octave4)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertTrue(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testDoubleFlat() {
+        let tone1 = Tone(accidental: .doubleFlat, noteLetter: .b, octave: .octave2)
+        let tone2 = Tone(accidental: nil, noteLetter: .a, octave: .octave2)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertTrue(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testDifferentOctaveNumbers() {
+        let tone1 = Tone(accidental: .sharp, noteLetter: .b, octave: .octave6)
+        let tone2 = Tone(accidental: .natural, noteLetter: .c, octave: .octave7)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertTrue(tone1.isEnharmonic(with: tone2))
+    }
+    
+    // MARK: Failures
+    
+    func testDifferentAccidentals() {
+        let tone1 = Tone(accidental: .flat, noteLetter: .d, octave: .octave1)
+        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
+    }
+    
+    func testDifferentOctaves() {
+        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave5)
+        let tone2 = Tone(accidental: .natural, noteLetter: .e, octave: .octave6)
+        
+        XCTAssertNotEqual(tone1, tone2)
+        XCTAssertFalse(tone1.isEnharmonic(with: tone2))
     }
 }


### PR DESCRIPTION
Resolves #77

* Add an `Enharmonic` protocol to check if two notes have the same sound, even if spelled differently (e.g. E-flat and D-sharp).
* Implement `Enharmonic` for Tone
* Add Midi Note number (used to calculate if two tones are enharmonic)
* Add tests for midi note number and Enharmonic
* Enharmonic comparison should also be added for key signatures and chords