### PR TITLE
Make Accidental non-optional

### DIFF
--- a/MusicNotationKit/MusicNotationKit/Key.swift
+++ b/MusicNotationKit/MusicNotationKit/Key.swift
@@ -10,9 +10,9 @@ public struct Key {
 	
 	fileprivate let type: KeyType
 	fileprivate let noteLetter: NoteLetter
-	fileprivate let accidental: Accidental?
+	fileprivate let accidental: Accidental
 	
-	public init(noteLetter: NoteLetter, accidental: Accidental? = nil, type: KeyType = .major) {
+	public init(noteLetter: NoteLetter, accidental: Accidental = .natural, type: KeyType = .major) {
 		self.noteLetter = noteLetter
 		self.accidental = accidental
 		self.type = type

--- a/MusicNotationKit/MusicNotationKit/Tone.swift
+++ b/MusicNotationKit/MusicNotationKit/Tone.swift
@@ -8,26 +8,25 @@
 
 public struct Tone {
 	
-	public let accidental: Accidental?
 	public let noteLetter: NoteLetter
-	public let octave: Octave
+	public let accidental: Accidental
+    public let octave: Octave
 	
-	public init(accidental: Accidental? = nil, noteLetter: NoteLetter, octave: Octave) {
-		self.accidental = accidental
+	public init(noteLetter: NoteLetter, accidental: Accidental = .natural, octave: Octave) {
 		self.noteLetter = noteLetter
+        self.accidental = accidental
 		self.octave = octave
 	}
 }
 
 extension Tone: CustomDebugStringConvertible {
 	public var debugDescription: String {
-		let accidentalString: String
-		if let accidental = accidental {
-			accidentalString = "\(accidental)"
-		} else {
-			accidentalString = ""
-		}
-		return "\(noteLetter)\(accidentalString)\(octave.rawValue)"
+        switch accidental {
+        case .natural:
+            return "\(noteLetter)\(octave.rawValue)"
+        default:
+            return "\(noteLetter)\(accidental)\(octave.rawValue)"
+        }
 	}
 }
 
@@ -58,16 +57,16 @@ extension Tone {
         }
         
         switch accidental {
-        case .flat?:
-            result -= 1
-        case .sharp?:
-            result += 1
-        case .doubleFlat?:
-            result -= 2
-        case .doubleSharp?:
-            result += 2
-        default:
+        case .natural:
             break
+        case .flat:
+            result -= 1
+        case .sharp:
+            result += 1
+        case .doubleFlat:
+            result -= 2
+        case .doubleSharp:
+            result += 2
         }
         
         return result

--- a/MusicNotationKit/MusicNotationKit/Tone.swift
+++ b/MusicNotationKit/MusicNotationKit/Tone.swift
@@ -7,27 +7,27 @@
 //
 
 public struct Tone {
-	
-	public let noteLetter: NoteLetter
-	public let accidental: Accidental
+    
+    public let noteLetter: NoteLetter
+    public let accidental: Accidental
     public let octave: Octave
-	
-	public init(noteLetter: NoteLetter, accidental: Accidental = .natural, octave: Octave) {
-		self.noteLetter = noteLetter
+    
+    public init(noteLetter: NoteLetter, accidental: Accidental = .natural, octave: Octave) {
+        self.noteLetter = noteLetter
         self.accidental = accidental
-		self.octave = octave
-	}
+        self.octave = octave
+    }
 }
 
 extension Tone: CustomDebugStringConvertible {
-	public var debugDescription: String {
+    public var debugDescription: String {
         switch accidental {
         case .natural:
             return "\(noteLetter)\(octave.rawValue)"
         default:
             return "\(noteLetter)\(accidental)\(octave.rawValue)"
         }
-	}
+    }
 }
 
 extension Tone: Equatable {

--- a/MusicNotationKit/MusicNotationKitTests/MeasureTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/MeasureTests.swift
@@ -26,7 +26,7 @@ class MeasureTests: XCTestCase {
     func testAddNote() {
         XCTAssertEqual(measure.notes[0].count, 0)
         measure.addNote(Note(noteDuration: .whole, tone: Tone(noteLetter: .c, octave: .octave0)))
-        measure.addNote(Note(noteDuration: .quarter, tone: Tone(accidental: .sharp, noteLetter: .d, octave: .octave0)))
+        measure.addNote(Note(noteDuration: .quarter, tone: Tone(noteLetter: .d, accidental: .sharp, octave: .octave0)))
         measure.addNote(Note(noteDuration: .whole))
         XCTAssertEqual(measure.notes[0].count, 3)
     }

--- a/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/ToneTests.swift
@@ -12,32 +12,32 @@ import MusicNotationKit
 class ToneTests: XCTestCase {
 
     func testTone1() {
-        let tone = Tone(accidental: nil, noteLetter: .c, octave: .octave3)
+        let tone = Tone(noteLetter: .c, octave: .octave3)
         XCTAssertTrue(tone.debugDescription == "c3")
     }
     
     func testTone2() {
-        let tone = Tone(accidental: .sharp, noteLetter: .g, octave: .octave6)
+        let tone = Tone(noteLetter: .g, accidental: .sharp, octave: .octave6)
         XCTAssertTrue(tone.debugDescription == "g♯6")
     }
 
     func testTone3() {
-        let tone = Tone(accidental: .flat, noteLetter: .e, octave: .octave2)
+        let tone = Tone(noteLetter: .e, accidental: .flat, octave: .octave2)
         XCTAssertTrue(tone.debugDescription == "e♭2")
     }
     
     func testTone4() {
-        let tone = Tone(accidental: .natural, noteLetter: .a, octave: .octave4)
-        XCTAssertTrue(tone.debugDescription == "a♮4")
+        let tone = Tone(noteLetter: .a, accidental: .natural, octave: .octave4)
+        XCTAssertTrue(tone.debugDescription == "a4")
     }
     
     func testTone5() {
-        let tone = Tone(accidental: .doubleSharp, noteLetter: .b, octave: .octave5)
+        let tone = Tone(noteLetter: .b, accidental: .doubleSharp, octave: .octave5)
         XCTAssertTrue(tone.debugDescription == "b𝄪5")
     }
     
     func testTone6() {
-        let tone = Tone(accidental: .doubleFlat, noteLetter: .f, octave: .octave7)
+        let tone = Tone(noteLetter: .f, accidental: .doubleFlat, octave: .octave7)
         XCTAssertTrue(tone.debugDescription == "f𝄫7")
     }
     
@@ -45,8 +45,8 @@ class ToneTests: XCTestCase {
     // MARK: Failures
     
     func testNotEqual() {
-        let tone1 = Tone(accidental: .flat, noteLetter: .b, octave: .octave5)
-        let tone2 = Tone(accidental: .flat, noteLetter: .b, octave: .octave4)
+        let tone1 = Tone(noteLetter: .b, accidental: .flat, octave: .octave5)
+        let tone2 = Tone(noteLetter: .b, accidental: .flat, octave: .octave4)
         
         XCTAssertNotEqual(tone1, tone2)
     }
@@ -54,8 +54,8 @@ class ToneTests: XCTestCase {
     // MARK: Successes
     
     func testEqual() {
-        let tone1 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
-        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        let tone1 = Tone(noteLetter: .d, accidental: .sharp, octave: .octave1)
+        let tone2 = Tone(noteLetter: .d, accidental: .sharp, octave: .octave1)
         
         XCTAssertEqual(tone1, tone2)
     }
@@ -64,25 +64,25 @@ class ToneTests: XCTestCase {
     // MARK: Successes
     
     func testRidiculouslyLowNote() {
-        let tone = Tone(accidental: .natural, noteLetter: .c, octave: .octaveNegative1)
+        let tone = Tone(noteLetter: .c, accidental: .natural, octave: .octaveNegative1)
         
         XCTAssertEqual(tone.midiNoteNumber, 0)
     }
     
     func testLowNote() {
-        let tone = Tone(accidental: .sharp, noteLetter: .f, octave: .octave1)
+        let tone = Tone(noteLetter: .f, accidental: .sharp, octave: .octave1)
         
         XCTAssertEqual(tone.midiNoteNumber, 30)
     }
     
     func testMidRangeNote() {
-        let tone = Tone(accidental: nil, noteLetter: .d, octave: .octave4)
+        let tone = Tone(noteLetter: .d, octave: .octave4)
         
         XCTAssertEqual(tone.midiNoteNumber, 62)
     }
     
     func testHighNote() {
-        let tone = Tone(accidental: .flat, noteLetter: .c, octave: .octave8)
+        let tone = Tone(noteLetter: .c, accidental: .flat, octave: .octave8)
         
         XCTAssertEqual(tone.midiNoteNumber, 107)
     }
@@ -91,24 +91,24 @@ class ToneTests: XCTestCase {
     // MARK: Failures
     
     func testDifferentAccidentals() {
-        let tone1 = Tone(accidental: .flat, noteLetter: .d, octave: .octave1)
-        let tone2 = Tone(accidental: .sharp, noteLetter: .d, octave: .octave1)
+        let tone1 = Tone(noteLetter: .d, accidental: .flat, octave: .octave1)
+        let tone2 = Tone(noteLetter: .d, accidental: .sharp, octave: .octave1)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertFalse(tone1.isEnharmonic(with: tone2))
     }
     
     func testSamePitchDifferentOctaves() {
-        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave5)
-        let tone2 = Tone(accidental: .natural, noteLetter: .e, octave: .octave6)
+        let tone1 = Tone(noteLetter: .e, accidental: .natural, octave: .octave5)
+        let tone2 = Tone(noteLetter: .e, accidental: .natural, octave: .octave6)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertFalse(tone1.isEnharmonic(with: tone2))
     }
     
     func testEnharmonicPitchDifferentOctaves() {
-        let tone1 = Tone(accidental: .doubleSharp, noteLetter: .f, octave: .octave2)
-        let tone2 = Tone(accidental: .natural, noteLetter: .g, octave: .octave5)
+        let tone1 = Tone(noteLetter: .f, accidental: .doubleSharp, octave: .octave2)
+        let tone2 = Tone(noteLetter: .g, accidental: .natural, octave: .octave5)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertFalse(tone1.isEnharmonic(with: tone2))
@@ -117,8 +117,8 @@ class ToneTests: XCTestCase {
     // MARK: Successes
     
     func testSameToneIsEnharmonic() {
-        let tone1 = Tone(accidental: .natural, noteLetter: .g, octave: .octave6)
-        let tone2 = Tone(accidental: .natural, noteLetter: .g, octave: .octave6)
+        let tone1 = Tone(noteLetter: .g, accidental: .natural, octave: .octave6)
+        let tone2 = Tone(noteLetter: .g, accidental: .natural, octave: .octave6)
         
         XCTAssertEqual(tone1, tone2)
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))
@@ -127,32 +127,32 @@ class ToneTests: XCTestCase {
     }
     
     func testEnharmonicNotEquatable() {
-        let tone1 = Tone(accidental: .flat, noteLetter: .a, octave: .octave3)
-        let tone2 = Tone(accidental: .sharp, noteLetter: .g, octave: .octave3)
+        let tone1 = Tone(noteLetter: .a, accidental: .flat, octave: .octave3)
+        let tone2 = Tone(noteLetter: .g, accidental: .sharp, octave: .octave3)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))
     }
     
     func testNaturalAndFlat() {
-        let tone1 = Tone(accidental: .natural, noteLetter: .e, octave: .octave4)
-        let tone2 = Tone(accidental: .flat, noteLetter: .f, octave: .octave4)
+        let tone1 = Tone(noteLetter: .e, accidental: .natural, octave: .octave4)
+        let tone2 = Tone(noteLetter: .f, accidental: .flat, octave: .octave4)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))
     }
     
     func testDoubleFlat() {
-        let tone1 = Tone(accidental: .doubleFlat, noteLetter: .b, octave: .octave2)
-        let tone2 = Tone(accidental: nil, noteLetter: .a, octave: .octave2)
+        let tone1 = Tone(noteLetter: .b, accidental: .doubleFlat, octave: .octave2)
+        let tone2 = Tone(noteLetter: .a, octave: .octave2)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))
     }
     
     func testDifferentOctaveNumbers() {
-        let tone1 = Tone(accidental: .sharp, noteLetter: .b, octave: .octave6)
-        let tone2 = Tone(accidental: .natural, noteLetter: .c, octave: .octave7)
+        let tone1 = Tone(noteLetter: .b, accidental: .sharp, octave: .octave6)
+        let tone2 = Tone(noteLetter: .c, accidental: .natural, octave: .octave7)
         
         XCTAssertNotEqual(tone1, tone2)
         XCTAssertTrue(tone1.isEnharmonic(with: tone2))

--- a/MusicNotationKit/MusicNotationKitTests/TupletTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/TupletTests.swift
@@ -12,8 +12,8 @@ import XCTest
 class TupletTests: XCTestCase {
 
 	let tone1 = Tone(noteLetter: .a, octave: .octave1)
-	let tone2 = Tone(accidental: .sharp, noteLetter: .b, octave: .octave1)
-	let tone3 = Tone(accidental: .natural, noteLetter: .d, octave: .octave1)
+	let tone2 = Tone(noteLetter: .b, accidental: .sharp, octave: .octave1)
+	let tone3 = Tone(noteLetter: .d, accidental: .natural, octave: .octave1)
 	let quarterRest = Note(noteDuration: .quarter)
 	let eighthRest = Note(noteDuration: .eighth)
     let dottedQuarterNote = Note(noteDuration: try! NoteDuration(value: .quarter, dotCount: 1),


### PR DESCRIPTION
Addresses issue #76 

I believe make the Accidental type non-optional for Tone and KeySignature will help prevent some odd behavior and make for a more consistent model.

I've also reordered the initializer for Tone to place accidental after note letter, which better matches how we natural refer to the notes (i.e. G-sharp, not sharp-G).