### PR TITLE
Implement `NoteCollection.groupingOrder`

### DIFF
--- a/MusicNotationKit/MusicNotationKit/Note.swift
+++ b/MusicNotationKit/MusicNotationKit/Note.swift
@@ -12,6 +12,7 @@ public struct Note: NoteCollection {
     public let noteCount = 1
     public let noteDuration: NoteDuration
     public let noteTimingCount = 1
+    public let groupingOrder = 1
     public var first: Note? { return self }
     public var last: Note? { return self }
 

--- a/MusicNotationKit/MusicNotationKit/NoteCollection.swift
+++ b/MusicNotationKit/MusicNotationKit/NoteCollection.swift
@@ -25,6 +25,10 @@ public protocol NoteCollection {
      */
     var noteTimingCount: Int { get }
 
+    /// The grouping order defined for this `NoteCollection`
+    var groupingOrder: Int { get }
+
+
     var first: Note? { get }
     var last: Note? { get }
 

--- a/MusicNotationKit/MusicNotationKit/Tuplet.swift
+++ b/MusicNotationKit/MusicNotationKit/Tuplet.swift
@@ -18,11 +18,17 @@ public struct Tuplet: NoteCollection {
         }
     }
     /// The number of notes of the specified duration that this tuplet contains
-    public let noteCount: Int
+    public var noteCount: Int {
+        return flatIndexes.count
+    }
+
     /// The duration of the notes that define this tuplet
     public let noteDuration: NoteDuration
     /// The number of notes that this tuplet fits in the space of
     public let noteTimingCount: Int
+
+    public var groupingOrder: Int
+
     public var first: Note? {
         return try? note(at: 0)
     }
@@ -33,7 +39,7 @@ public struct Tuplet: NoteCollection {
     internal var flatIndexes: [[Int]] = [[Int]]()
 
     /**
-     This maps the standard number of notes in the tuplet (`noteCount`), to the number of notes the tuplet should fit
+     This maps the standard number of notes in the tuplet (`groupingOrder`), to the number of notes the tuplet should fit
      in the space of (`noteTimingCount`).
      */
     public static let standardRatios = [
@@ -66,7 +72,7 @@ public struct Tuplet: NoteCollection {
         guard count > 1 else {
             throw TupletError.countMustBeLargerThan1
         }
-        noteCount = count
+        groupingOrder = count
         let fullTupletTicks = count * baseNoteDuration.ticks
         let notesTicks = notes.reduce(0) { prev, noteCollection in
             return prev + noteCollection.ticks
@@ -419,7 +425,7 @@ public struct Tuplet: NoteCollection {
         // TODO: We should probably figure out note count so that this switch on type isn't needed.
         let accumulateNoteCount: (Int, NoteCollection) -> Int = { prev, currentNoteCollection in
             if let currentTuplet = currentNoteCollection as? Tuplet {
-                return prev + currentTuplet.flatIndexes.count
+                return prev + currentTuplet.noteCount
             } else {
                 return prev + currentNoteCollection.noteCount
             }
@@ -443,7 +449,7 @@ public struct Tuplet: NoteCollection {
     private func validate() -> Bool {
         var isValid = true
         var notesTicks = 0
-        let fullTupletTicks = noteCount * noteDuration.ticks
+        let fullTupletTicks = groupingOrder * noteDuration.ticks
         for noteCollection in notes {
             if let tuplet = noteCollection as? Tuplet {
                 if !isValid {

--- a/MusicNotationKit/MusicNotationKit/Tuplet.swift
+++ b/MusicNotationKit/MusicNotationKit/Tuplet.swift
@@ -27,7 +27,7 @@ public struct Tuplet: NoteCollection {
     /// The number of notes that this tuplet fits in the space of
     public let noteTimingCount: Int
 
-    public var groupingOrder: Int
+    public let groupingOrder: Int
 
     public var first: Note? {
         return try? note(at: 0)

--- a/MusicNotationKit/MusicNotationKitTests/MeasureTests.swift
+++ b/MusicNotationKit/MusicNotationKitTests/MeasureTests.swift
@@ -179,6 +179,22 @@ class MeasureTests: XCTestCase {
         }
     }
 
+    func testStartTieInNestedTuplet() {
+        assertNoErrorThrown {
+            let note = Note(noteDuration: .eighth,
+                            tone: Tone(noteLetter: .c, octave: .octave1))
+            let triplet = try Tuplet(3, .eighth, notes: [note, note, note])
+            let tuplet = try Tuplet(3, .eighth, notes: [triplet, note])
+            measure.addTuplet(tuplet)
+            measure.addNote(note)
+            try measure.startTie(at: 3, inSet: 0)
+            let note1 = try measure.note(at: 3)
+            let note2 = try measure.note(at: 4)
+            XCTAssert(note1.tie == .begin)
+            XCTAssert(note2.tie == .end)
+        }
+    }
+
     // MARK: - startTie(at:)
     // MARK: Failures
 


### PR DESCRIPTION
Grouping order is used to calculate the total number of ticks in a
`Tuplet`. `NoteCollection.noteCount` returns now the number of notes in
the notes container.
